### PR TITLE
Color()は参照渡しなので、誤って書き換えられないようにcolor()を使うようにする

### DIFF
--- a/Scripts/WAIEI Core/FILE.lua
+++ b/Scripts/WAIEI Core/FILE.lua
@@ -109,7 +109,7 @@ local function openFile(...)
 			response = response .. ':' .. split(';',params[i])[1]
 		end
 		--]]
-		-- こんな方法あったのか
+		-- テーブルを「:」で結合して文字列にする
 		local response = table.concat(params, ':', 2, #params)
 		return split(";",response)[1]
 	end

--- a/Scripts/WAIEI Core/GROUP.lua
+++ b/Scripts/WAIEI Core/GROUP.lua
@@ -1,7 +1,7 @@
 -- Group.ini
 
 -- デフォルト値
-local defaultMenuColor = Color('White')
+local defaultMenuColor = color('1, 1, 1, 1')
 local defaultMeterType = 'DDR'
 
 --[[

--- a/Scripts/WAIEI Core/QRCODE.lua
+++ b/Scripts/WAIEI Core/QRCODE.lua
@@ -5,7 +5,7 @@
 --]]
 local allQrData = {}
 local qrColors = {}
-local defaultQrColors = {Color('White'), Color('Black')}
+local defaultQrColors = {color('1, 1, 1, 1'), color('0, 0, 0, 1')}
 local function QrCodeActor(...)
 	local self, id, size, border, line = ...
 	line   = line or 50

--- a/Scripts/WAIEI Core/SHARE.lua
+++ b/Scripts/WAIEI Core/SHARE.lua
@@ -410,7 +410,7 @@ local function shareActor(...)
 	end
 	--[[
 		このActorをコピーしてEvaluationに貼り付けることで自分好みにカスタムできます
-		以下二つの変数の初期化も必要です
+		以下の変数の初期化も必要です
 		local shareUrl = {}
 	--]]
 	return Def.Actor({

--- a/Scripts/WAIEI Core/VER.lua
+++ b/Scripts/WAIEI Core/VER.lua
@@ -1,6 +1,6 @@
 -- バージョン
-local ver = 23
-local date = '20200120'
+local ver = 24
+local date = '20200315'
 local function coreVer()
 	return ver
 end


### PR DESCRIPTION
```Lua
local color = Color('White')
color[4] = 0.5
```
という書き方をするとそれ以降`Color('White')`を呼び出したときに
透明度0.5が反映されてしまうので`color()`でその都度生成するように修正